### PR TITLE
correcting error when loading the lang

### DIFF
--- a/system.json
+++ b/system.json
@@ -131,6 +131,6 @@
   "Seal Chamber": "Cámara de sellado",
   "Corridor": "Corredor",
   "Hermit Gunsmith": "Armero ermitaño",
-  "Clock Room": "Habitación del reloj",
+  "Clock Room": "Habitación del reloj"
 }
 


### PR DESCRIPTION
correcting error when loading the language,the error was caused by a `,` after deleting it no longer gave me the error 